### PR TITLE
Remove 'del' module

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -13,7 +13,6 @@
 ************************************************/
 var gulp   = require('gulp'),
     chalk  = require('chalk'),
-    // del    = require('del'),
     fs     = require('fs'),
     plug   = require('gulp-load-plugins')({
               scope: ['devDependencies'],
@@ -191,13 +190,7 @@ gulp.task( 'html-me', function(){
 
 gulp.task( 'clean-me', [ 'css-me', 'js-me' ], function(){
 
-  var dels = 'Cleaned up the following: \n';
-  del( ['tmp/**','tmp'] , function (err, deletedFiles) {
-    deletedFiles.forEach( function( val, index ){
-        dels +=  '  - '+val+'\n';
-    });
-    loggit(dels);
-  });
+  del( ['tmp/**','tmp'] );
 
 });
 
@@ -227,6 +220,25 @@ errorLog = function (er){
             "*****************************************\n";
 
   console.log( chalk.red( log )  );
+},
+del = function(files){
+
+  if( files.isArray ){
+    var str = "Deleted the following files:\n";
+    files.forEach(function(file) {
+      fs.unlink(files, function(err){
+        if(err){ throw err; }
+        str += " - "+file+"\n";
+      });
+    })
+    loggit(str);
+  }else{
+    fs.unlink(files, function(err){
+      if(err){ throw err; }
+      loggit('Deleted '+files+'successfully!');
+    });
+  }
+
 },
 timePlz = function(){
 

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -13,7 +13,8 @@
 ************************************************/
 var gulp   = require('gulp'),
     chalk  = require('chalk'),
-    del    = require('del'),
+    // del    = require('del'),
+    fs     = require('fs'),
     plug   = require('gulp-load-plugins')({
               scope: ['devDependencies'],
               replaceString: 'gulp-',


### PR DESCRIPTION
No need for 'del' when you get fs.unlink for free.

I mean, seeing as fs.unlink isn't really descriptive of what we're doing with it, you could write your own del utility function in the gulpfile that does the same.
