### PR TITLE
Fixed a 'file not found' exception related to CSS source maps and bootst...

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -596,6 +596,7 @@ EggsGennyGenerator = yeoman.generators.Base.extend({
                 //  Copy Bootstrap if need be
                 if( depsCSS.bootstrap ){
                   utils.copyThis( 'app/lib_tmp/bootstrap/dist/css/bootstrap.css', 'app/lib/css/bootstrap.css' );
+                  utils.copyThis( 'app/lib_tmp/bootstrap/dist/css/bootstrap.css.map', 'app/lib/css/bootstrap.css.map' );
                 }
                 //  Copy Skeleton if need be
                 if( depsCSS.skeleton ){


### PR DESCRIPTION
This fixes the 'file not found' exception in the terminal when loading the bootstrap.css file inside Chrome.

This error can also be fixed by removing the line in bootstrap.css, but I don't really like that solution.
