### PR TITLE
Add Crass for CSS minification

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -575,7 +575,6 @@ EggsGennyGenerator = yeoman.generators.Base.extend({
                 "gulp-livereload": "~3.0.2",
                 "gulp-load-plugins": "~0.8.0",
                 "gulp-crass": "~0.1.2",
-                "gulp-minify-css": "~0.3.11",
                 "gulp-uglify": "~1.0.2",
                 "gulp-uncss": "~0.5.2"
               }

--- a/app/index.js
+++ b/app/index.js
@@ -574,6 +574,7 @@ EggsGennyGenerator = yeoman.generators.Base.extend({
                 "gulp-jshint": "~1.9.0",
                 "gulp-livereload": "~3.0.2",
                 "gulp-load-plugins": "~0.8.0",
+                "gulp-crass": "~0.1.2",
                 "gulp-minify-css": "~0.3.11",
                 "gulp-uglify": "~1.0.2",
                 "gulp-uncss": "~0.5.2"

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -148,7 +148,7 @@ gulp.task( 'uncss-me', ['css-me',<% if (depsJS.angular) { %> 'partials-me',<% } 
           .pipe(plug.uncss({
             html: <% if (depsJS.angular) { %>glob.sync('build/**/*.html')<% }else { %>['build/index.html']<% } %>
           }))
-          .pipe( plug.minifyCss() )
+          .pipe( plug.crass({pretty: false}) )
           .pipe(gulp.dest('build/css/'));
 });
 


### PR DESCRIPTION
Adds [gulp-crass](https://www.npmjs.com/package/gulp-crass) to the build (instead of minify-css).
